### PR TITLE
Simplify solution for Task v6 17.05 (Haskell)

### DIFF
--- a/notebooks/task_v6_17_05_haskell.ipynb
+++ b/notebooks/task_v6_17_05_haskell.ipynb
@@ -18,6 +18,7 @@
     "import Data.List\n",
     "import Data.Char\n",
     "import Data.Function\n",
+    "import Data.Maybe\n",
     "import qualified Data.IntMap as IntMap"
    ]
   },
@@ -35,9 +36,8 @@
     "computeState (oldMap, oldLevel) (index, c) =\n",
     "    let\n",
     "        newLevel = (if isDigit c then succ else pred) oldLevel\n",
-    "        oldRange = IntMap.findWithDefault (index, index) newLevel oldMap\n",
-    "        newRange = (fst oldRange, index)\n",
-    "        newMap = IntMap.insert newLevel newRange oldMap\n",
+    "        rangeStart = fromMaybe index $ fmap fst $ IntMap.lookup newLevel oldMap\n",
+    "        newMap = IntMap.insert newLevel (rangeStart, index) oldMap\n",
     "    in\n",
     "        (newMap, newLevel)"
    ]


### PR DESCRIPTION
Our first solution extracted a pair from the map and stored it in
oldRange, or set it to (index, index) if the key newLevel was not in
the map. However, the end of the range (i.e., the second number in the
pair) was never used because (fst oldRange, index) was the new range
that was written to the map.

This patch makes this a bit more elegant by storing only the start of
the range (i.e., the first number of the pair). This means that we only
need a default value for the range start if the map lookup returns
Nothing.
